### PR TITLE
Update for macOS 12.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ OpenAL (native), Mac OS X 10.9.5
 * ALC_EXT_CAPTURE
 * ALC_EXT_MAC_OSX
 
-OpenAL (native), Mac OS X 10.10.5, 10.11.1
-------------------------------------------
+OpenAL (native), Mac OS X 10.10.5, 10.11.1, 12.6.1
+--------------------------------------------------
 
 * AL_EXT_EXPONENT_DISTANCE
 * AL_EXT_float32


### PR DESCRIPTION
Maybe I should mention that Apple has deprecated OpenAL in 10.15 because they're Apple, so nothing new should come.

This did require a special build of openal-info (from alsoft), as the default one links to alsoft by cmake. The build command was extracted using `make VERBOSE=1` and the `libopenal.1.23.1.dylib` component was replaced with `-framework OpenAL`.

Honestly I have no idea how this linkage works at all. `otool -L` points me to /System/Library/Frameworks/OpenAL.framework/Versions/A/OpenAL, which does not exist! But somehow the program runs. O the forbidden fruit and its mysteries.